### PR TITLE
Add Athlon X4 files

### DIFF
--- a/Bristol Ridge.yaml
+++ b/Bristol Ridge.yaml
@@ -1,0 +1,21 @@
+name: Bristol Ridge
+humanName: Bristol Ridge
+type: CPU Architecture
+topHeader: 'SELECT CPU:'
+data:
+  Lithography: 28 nm
+  Sockets:
+  - AM4
+  - FM2+
+  Foundry: Global Foundries
+sections:
+  - header: 7th GEN. QUAD CORE
+    members:
+      - Athlon X4 970
+      - Athlon X4 950
+      - Athlon X4 940
+  - header: NSTS QUAD CORE
+    members:
+      - Athlon X4 845
+      - Athlon X4 835
+

--- a/Bristol Ridge/Athlon-X4-940.yaml
+++ b/Bristol Ridge/Athlon-X4-940.yaml
@@ -1,0 +1,12 @@
+name: Athlon X4 940
+humanName: Athlon X4 940
+isPart: true
+type: CPU
+inherits:
+  - Excavator 4C Base
+data:
+  Base Frequency: 3.2 GHz
+  Boost Frequency: 3.6 GHz
+  TDP: 45 W - 65 W
+  L3 Cache (Total): x
+

--- a/Bristol Ridge/Athlon-X4-950.yaml
+++ b/Bristol Ridge/Athlon-X4-950.yaml
@@ -1,0 +1,12 @@
+name: Athlon X4 950
+humanName: Athlon X4 950
+isPart: true
+type: CPU
+inherits:
+  - Excavator 4C Base
+data:
+  Base Frequency: 3.5 GHz
+  Boost Frequency: 3.8 GHz
+  TDP: 45 W - 65 W
+  L3 Cache (Total): x
+

--- a/Bristol Ridge/Athlon-X4-970.yaml
+++ b/Bristol Ridge/Athlon-X4-970.yaml
@@ -1,0 +1,12 @@
+name: Athlon X4 970
+humanName: Athlon X4 970
+isPart: true
+type: CPU
+inherits:
+  - Excavator 4C Base
+data:
+  Base Frequency: 3.8 GHz
+  Boost Frequency: 4.0 GHz
+  TDP: 65 W
+  L3 Cache (Total): x
+

--- a/Bristol Ridge/Excavator-4C-Base.yaml
+++ b/Bristol Ridge/Excavator-4C-Base.yaml
@@ -1,0 +1,9 @@
+hidden: true
+name: Excavator 4C Base
+inherits:
+  - Bristol-Ridge
+data:
+  Release Date: '2017-07-27'
+  Core Count: 4
+  Thread Count: 4
+  L2 Cache (Total): 2 MiB

--- a/Bristol-Ridge-inherit.yaml
+++ b/Bristol-Ridge-inherit.yaml
@@ -1,0 +1,7 @@
+hidden: true
+name: Bristol Ridge
+data:
+  Architecture: Excavator
+  Lithography: 28 nm
+  Socket: AM4
+  Unlocked: true

--- a/Carrizo-inherit.yaml
+++ b/Carrizo-inherit.yaml
@@ -1,0 +1,7 @@
+hidden: true
+name: Carrizo
+data:
+  Architecture: Excavator
+  Lithography: 28 nm
+  Socket: FM2+
+  Unlocked: true

--- a/Carrizo.yaml
+++ b/Carrizo.yaml
@@ -1,0 +1,16 @@
+name: Bristol Ridge
+humanName: Bristol Ridge
+type: CPU Architecture
+topHeader: 'SELECT CPU:'
+data:
+  Lithography: 28 nm
+  Sockets:
+  - FM2+
+  Foundry: Global Foundries
+sections:
+  - header: NSTS QUAD CORE
+    members:
+      - Athlon X4 845
+      - Athlon X4 835
+
+

--- a/Carrizo/Athlon-X4-835.yaml
+++ b/Carrizo/Athlon-X4-835.yaml
@@ -1,0 +1,12 @@
+name: Athlon X4 835
+humanName: Athlon X4 835
+isPart: true
+type: CPU
+inherits:
+  - Carrizo-Base
+data:
+  Base Frequency: 3.1 GHz
+  Boost Frequency: 3.4 GHz
+  TDP: 65 W
+  L3 Cache (Total): x
+

--- a/Carrizo/Athlon-X4-845.yaml
+++ b/Carrizo/Athlon-X4-845.yaml
@@ -1,0 +1,12 @@
+name: Athlon X4 845
+humanName: Athlon X4 845
+isPart: true
+type: CPU
+inherits:
+  - Carrizo-Base
+data:
+  Base Frequency: 3.5 GHz
+  Boost Frequency: 3.8 GHz
+  TDP: 65 W
+  L3 Cache (Total): x
+

--- a/Carrizo/Carrizo-Base.yaml
+++ b/Carrizo/Carrizo-Base.yaml
@@ -1,0 +1,9 @@
+hidden: true
+name: Excavator 4C Base
+inherits:
+  - Carrizo
+data:
+  Release Date: '2016-02-02'
+  Core Count: 4
+  Thread Count: 4
+  L2 Cache (Total): 2 MiB

--- a/Llano-inherit.yaml
+++ b/Llano-inherit.yaml
@@ -1,0 +1,6 @@
+hidden: true
+name: Llano
+data:
+  Architecture: K10
+  Lithography: 32 nm
+  Socket: FM1

--- a/Llano.yaml
+++ b/Llano.yaml
@@ -1,0 +1,20 @@
+name: Llano
+humanName: Llano
+type: CPU Architecture
+topHeader: 'SELECT CPU:'
+data:
+  Release Date: '2011-Q2 | 2012-Q1'
+  Lithography: 32 nm
+  Sockets:
+  - FM1
+  Foundry: Global Foundries
+sections:
+  - header: 3rd GEN. QUAD CORE
+    members:
+      - Athlon II X4 651K
+      - Athlon II X4 651
+      - Athlon II X4 641
+      - Athlon II X4 638
+      - Athlon II X4 631
+
+  

--- a/Llano/Athlon-II-X4-631.yaml
+++ b/Llano/Athlon-II-X4-631.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 2.6 GHz
+  Boost Frequency: x
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): x
+  TDP: 100 W
+  Release Date: '2012-08-15'
+  Unlocked: not true
+inherits:
+  - Llano
+name: Athlon II X4 631
+humanName: Athlon II X4 631

--- a/Llano/Athlon-II-X4-638.yaml
+++ b/Llano/Athlon-II-X4-638.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 2.7 GHz
+  Boost Frequency: x
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): x
+  TDP: 65 W
+  Release Date: '2012-02-08'
+  Unlocked: not true
+inherits:
+  - Llano
+name: Athlon II X4 638
+humanName: Athlon II X4 638

--- a/Llano/Athlon-II-X4-641.yaml
+++ b/Llano/Athlon-II-X4-641.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 2.8 GHz
+  Boost Frequency: x
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): x
+  TDP: 100 W
+  Release Date: '2012-02-08'
+  Unlocked: not true
+inherits:
+  - Llano
+name: Athlon II X4 641
+humanName: Athlon II X4 641

--- a/Llano/Athlon-II-X4-651.yaml
+++ b/Llano/Athlon-II-X4-651.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 3.0 GHz
+  Boost Frequency: x
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): x
+  TDP: 100 W
+  Release Date: '2011-11-14'
+  Unlocked: not true
+inherits:
+  - Llano
+name: Athlon II X4 651
+humanName: Athlon II X4 651

--- a/Llano/Athlon-II-X4-651K.yaml
+++ b/Llano/Athlon-II-X4-651K.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 3.0 GHz
+  Boost Frequency: x
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): x
+  TDP: 100 W
+  Release Date: '2012-Q1'
+  Unlocked: true
+inherits:
+  - Llano
+name: Athlon II X4 651K
+humanName: Athlon II X4 651K

--- a/Trinity-inherit.yaml
+++ b/Trinity-inherit.yaml
@@ -1,0 +1,6 @@
+hidden: true
+name: Trinity
+data:
+  Architecture: Piledriver
+  Lithography: 32 nm
+  Socket: FM2

--- a/Trinity.yaml
+++ b/Trinity.yaml
@@ -1,0 +1,16 @@
+name: Trinity
+humanName: Trinity
+type: CPU Architecture
+topHeader: 'SELECT CPU:'
+data:
+  Release Date: '2013-06-01'
+  Lithography: 32 nm
+  Sockets:
+  - FM2
+  Foundry: Global Foundries
+sections:
+  - header: 4th GEN. QUAD CORE
+    members:
+      - Athlon X4 750K
+      - Athlon X4 740
+  

--- a/Trinity/Athlon-X4-740.yaml
+++ b/Trinity/Athlon-X4-740.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 3.2 GHz
+  Boost Frequency: 3.7 GHz
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): 4 MiB
+  TDP: 65 W
+  Release Date: '2012-10-01'
+  Unlocked: not true
+inherits:
+  - Trinity
+name: Athlon X4 740
+humanName: Athlon X4 740

--- a/Trinity/Athlon-X4-750K.yaml
+++ b/Trinity/Athlon-X4-750K.yaml
@@ -1,0 +1,16 @@
+isPart: true
+type: CPU
+data:
+  Thread Count: 4
+  Core Count: 4
+  Base Frequency: 3.4 GHz
+  Boost Frequency: 4.0 GHz
+  L2 Cache (Total): 4 MiB
+  L3 Cache (Total): 4 MiB
+  TDP: 100 W
+  Release Date: '2012-10-01'
+  Unlocked: true
+inherits:
+  - Trinity
+name: Athlon X4 760K
+humanName: Athlon X4 760K


### PR DESCRIPTION
Added .ymal files for Athlon X4 family of desktop processors from Bulldozer arch. all the way to Excavator, includes Llano, Trinity, Carrizo and latest 2017 line Bristol Ridge